### PR TITLE
Removes files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "type": "git",
     "url": "https://github.com/thejameskyle/backbone.linkview.git"
   },
-  "files": [
-    "app"
-  ],
   "keywords": [],
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",


### PR DESCRIPTION
This was preventing the library from publishing to npm correctly.
# 

You will need to cut a new release after this lands, @thejameskyle. This was a regression I didn't catch until just now when I converted the boilerplate to Yeoman! Thanks to @jeffijoe for help in figuring it out :)
